### PR TITLE
Use event checking instead of checking user agent

### DIFF
--- a/3dtouch.js
+++ b/3dtouch.js
@@ -21,7 +21,7 @@ function onTouchEnd(e) {
 
 // use timeout-based method only on devices lower than iOS 10
 function checkForce(e) {
-  if(getiOSVersion() < 10) {
+  if('ontouchforcechange' in document === false) {
     touch = e.touches[0];
     setTimeout(refreshForceValue.bind(touch), 10);
   }
@@ -65,16 +65,6 @@ function addForceTouchToElement(elem) {
   elem.addEventListener('touchend', onTouchEnd, false);
   elem.addEventListener('webkitmouseforcechanged', onClickForceChange, false);
   elem.addEventListener('touchforcechange', onTouchForceChange, false);
-}
-
-// get iOS version number
-function getiOSVersion() {
-  if(window.navigator.userAgent.match( /iP(hone|od|ad)/)){
-    var iOSVersion = parseFloat(String(window.navigator.userAgent.match(/[0-9]*_[0-9]/)).split('_')[0]+'.'+String(window.navigator.userAgent.match(/[0-9]_[0-9]/)).split('_')[1]);
-    return iOSVersion;
-  }
-
-  return false;
 }
 
 addForceTouchToElement(element);


### PR DESCRIPTION
This method checks that the “ontouchforcechange” event exists inside
the document. This means you don’t have to use the user agent checking
because that event is only available in iOS 10 or higher.

This is also more explicit because you only want to run the older
timeout method if the new “touchforcechange” is not called.
